### PR TITLE
Changes for Beat Saber 1.37.4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/.idea

--- a/HitsoundTweaks/HitsoundTweaksController.cs
+++ b/HitsoundTweaks/HitsoundTweaksController.cs
@@ -1,4 +1,5 @@
 ﻿using BeatSaberMarkupLanguage.Settings;
+using BeatSaberMarkupLanguage.Util;
 using HarmonyLib;
 using HitsoundTweaks.Configuration;
 using UnityEngine;
@@ -64,8 +65,8 @@ namespace HitsoundTweaks
             var harmony = new Harmony("com.galaxymaster.hitsoundtweaks");
             harmony.PatchAll();
 
-            BSMLSettings.instance.AddSettingsMenu("HitsoundTweaks", "HitsoundTweaks.UI.ModSettingsView.bsml", PluginConfig.Instance);
-
+            MainMenuAwaiter.MainMenuInitializing += AddSettingsMenuOnMenuInitialized;
+            
             Plugin.Log?.Debug($"{name}: Awake()");
         }
 
@@ -80,5 +81,10 @@ namespace HitsoundTweaks
 
         }
         #endregion
+        
+        private static void AddSettingsMenuOnMenuInitialized()
+        {
+            BSMLSettings.Instance.AddSettingsMenu("HitsoundTweaks", "HitsoundTweaks.UI.ModSettingsView.bsml", PluginConfig.Instance);
+        }
     }
 }


### PR DESCRIPTION
Since 1.37.4, a rebuild is necessary. In that time BSML did some refactoring and now you have to properly assign settings menus after the main menu has loaded. The `MainMenuAwaiter` class provides a event to do this.