### PR TITLE
Fix default config values getting skipped by BSML

### DIFF
--- a/HitsoundTweaks/Configuration/PluginConfig.cs
+++ b/HitsoundTweaks/Configuration/PluginConfig.cs
@@ -1,5 +1,4 @@
-﻿using BeatSaberMarkupLanguage.Attributes;
-using IPA.Config.Stores;
+﻿using IPA.Config.Stores;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo(GeneratedStore.AssemblyVisibilityTarget)]
@@ -7,24 +6,11 @@ namespace HitsoundTweaks.Configuration;
 
 internal class PluginConfig
 {
-    [UIValue("ignore-saber-speed")]
     public virtual bool IgnoreSaberSpeed { get; set; } = false;
-
-    [UIValue("static-sound-pos")]
     public virtual bool StaticSoundPos { get; set; } = false;
-
-    [UIValue("enable-spatialization")]
     public virtual bool EnableSpatialization { get; set; } = true;
-
-    [UIValue("random-pitch-min")]
     public virtual float RandomPitchMin { get; set; } = 0.9f;
-
-    [UIValue("random-pitch-max")]
     public virtual float RandomPitchMax { get; set; } = 1.2f;
-
-    [UIValue("enable-chain-element-hitsounds")]
     public virtual bool EnableChainElementHitsounds { get; set; } = false;
-
-    [UIValue("chain-element-volume-multiplier")]
     public virtual float ChainElementVolumeMultiplier { get; set; } = 0.8f;
 }

--- a/HitsoundTweaks/Installers/MenuInstaller.cs
+++ b/HitsoundTweaks/Installers/MenuInstaller.cs
@@ -7,6 +7,7 @@ public class MenuInstaller : Installer
 {
     public override void InstallBindings()
     {
+        Container.Bind<SettingsMenu>().AsSingle();
         Container.BindInterfacesTo<SettingsMenuManager>().AsSingle();
     }
 }

--- a/HitsoundTweaks/UI/SettingsMenu.cs
+++ b/HitsoundTweaks/UI/SettingsMenu.cs
@@ -1,0 +1,63 @@
+using BeatSaberMarkupLanguage.Attributes;
+using HitsoundTweaks.Configuration;
+
+namespace HitsoundTweaks.UI;
+
+internal class SettingsMenu
+{
+    private readonly PluginConfig config;
+
+    public SettingsMenu(PluginConfig config)
+    {
+        this.config = config;
+    }
+
+    [UIValue("ignore-saber-speed")]
+    public bool IgnoreSaberSpeed
+    {
+        get => config.IgnoreSaberSpeed;
+        set => config.IgnoreSaberSpeed = value;
+    }
+
+    [UIValue("static-sound-pos")]
+    public bool StaticSoundPos
+    {
+        get => config.StaticSoundPos;
+        set => config.StaticSoundPos = value;
+    }
+
+    [UIValue("enable-spatialization")]
+    public bool EnableSpatialization
+    {
+        get => config.EnableSpatialization;
+        set => config.EnableSpatialization = value;
+    }
+
+    [UIValue("random-pitch-min")]
+    public float RandomPitchMin
+    {
+        get => config.RandomPitchMin;
+        set => config.RandomPitchMin = value;
+    }
+
+    [UIValue("random-pitch-max")]
+    public float RandomPitchMax
+    {
+        get => config.RandomPitchMax;
+        set => config.RandomPitchMax = value;
+    }
+
+    [UIValue("enable-chain-element-hitsounds")]
+    public bool EnableChainElementHitsounds
+    {
+        get => config.EnableChainElementHitsounds;
+        set => config.EnableChainElementHitsounds = value;
+    }
+
+    [UIValue("chain-element-volume-multiplier")]
+    public float ChainElementVolumeMultiplier
+    {
+        get => config.ChainElementVolumeMultiplier;
+        set => config.ChainElementVolumeMultiplier = value;
+    }
+}

--- a/HitsoundTweaks/UI/SettingsMenuManager.cs
+++ b/HitsoundTweaks/UI/SettingsMenuManager.cs
@@ -1,5 +1,4 @@
 using BeatSaberMarkupLanguage.Settings;
-using HitsoundTweaks.Configuration;
 using System;
 using Zenject;
 
@@ -8,20 +7,20 @@ namespace HitsoundTweaks.UI;
 public class SettingsMenuManager : IInitializable, IDisposable
 {
     private readonly BSMLSettings bsmlSettings;
-    private readonly PluginConfig config;
+    private readonly SettingsMenu settingsMenu;
 
     private const string SettingsMenuName = "HitsoundTweaks";
     private const string ResourcePath = "HitsoundTweaks.UI.ModSettingsView.bsml";
 
-    private SettingsMenuManager(BSMLSettings bsmlSettings, PluginConfig config)
+    private SettingsMenuManager(BSMLSettings bsmlSettings, SettingsMenu settingsMenu)
     {
         this.bsmlSettings = bsmlSettings;
-        this.config = config;
+        this.settingsMenu = settingsMenu;
     }
 
     public void Initialize()
     {
-        bsmlSettings.AddSettingsMenu(SettingsMenuName, ResourcePath, config);
+        bsmlSettings.AddSettingsMenu(SettingsMenuName, ResourcePath, settingsMenu);
     }
 
     public void Dispose()


### PR DESCRIPTION
as i suspected, it wasn't a good idea using the config instance as the settings menu. i'm not entirely sure why this happens but when generating the config this way, and i'm assuming upon the menu parsing, all of the values get set to `default(T)`. might be some jank unity stuff to do with property serialization, but not much of a clue.

i've made a separate instance for the BSML menu, which works just fine, and it doesn't overwrite the default values in the bsipa config.