### PR TITLE
Added new features.

### DIFF
--- a/HitsoundTweaks/Configuration/PluginConfig.cs
+++ b/HitsoundTweaks/Configuration/PluginConfig.cs
@@ -10,9 +10,6 @@ internal class PluginConfig
     [UIValue("ignore-saber-speed")]
     public virtual bool IgnoreSaberSpeed { get; set; } = false;
 
-    [UIValue("PlayHitsoundOnlyOnCut")]
-    public virtual bool PlayHitsoundOnlyOnCut { get; set; } = false;
-
     [UIValue("PauseHitSoundWhenMissed")]
     public virtual bool PauseHitSoundWhenMissed { get; set; } = false;
 

--- a/HitsoundTweaks/Configuration/PluginConfig.cs
+++ b/HitsoundTweaks/Configuration/PluginConfig.cs
@@ -1,4 +1,4 @@
-﻿using BeatSaberMarkupLanguage.Attributes;
+using BeatSaberMarkupLanguage.Attributes;
 using IPA.Config.Stores;
 using System.Runtime.CompilerServices;
 
@@ -10,11 +10,20 @@ internal class PluginConfig
     [UIValue("ignore-saber-speed")]
     public virtual bool IgnoreSaberSpeed { get; set; } = false;
 
+    [UIValue("PlayHitsoundOnlyOnCut")]
+    public virtual bool PlayHitsoundOnlyOnCut { get; set; } = false;
+
+    [UIValue("PauseHitSoundWhenMissed")]
+    public virtual bool PauseHitSoundWhenMissed { get; set; } = false;
+
     [UIValue("static-sound-pos")]
     public virtual bool StaticSoundPos { get; set; } = false;
 
     [UIValue("enable-spatialization")]
     public virtual bool EnableSpatialization { get; set; } = true;
+
+    [UIValue("followAfterCut")]
+    public virtual bool followAfterCut { get; set; } = false;
 
     [UIValue("random-pitch-min")]
     public virtual float RandomPitchMin { get; set; } = 0.9f;

--- a/HitsoundTweaks/HarmonyPatches/NoteCutSoundEffect_PauseOnMiss_Patch.cs
+++ b/HitsoundTweaks/HarmonyPatches/NoteCutSoundEffect_PauseOnMiss_Patch.cs
@@ -1,0 +1,79 @@
+using HitsoundTweaks.Configuration;
+using SiraUtil.Affinity;
+using UnityEngine;
+
+namespace HitsoundTweaks.HarmonyPatches;
+
+/*
+ * For original hitsounds: always schedule playback, but pause the hitsound if the note is missed.
+ * Unpause for any slice (good or bad cut). Repause if the note is missed.
+ * This preserves the game's scheduling logic and works for vanilla hitsounds.
+ *
+ */
+internal class NoteCutSoundEffect_PauseOnMiss_Patch : IAffinity
+{
+    private readonly PluginConfig config;
+    private NoteCutSoundEffect_PauseOnMiss_Patch(PluginConfig config)
+    {
+        this.config = config;
+    }
+
+    public static bool isNoteShort;
+    [AffinityPatch(typeof(NoteCutSoundEffectManager), nameof(NoteCutSoundEffectManager.HandleNoteWasSpawned))]
+    private void Postfix(NoteController noteController, float ____beatAlignOffset)
+    {
+        // Determine if the note is short for use in muting logic, this is needed to prevent spatialization artifacts on short notes.
+        NoteData noteData = noteController.noteData;
+        if (config.PauseHitSoundWhenMissed)
+        {
+            isNoteShort = noteData.timeToPrevColorNote < ____beatAlignOffset;
+        }
+    }
+
+    [AffinityPatch(typeof(NoteCutSoundEffect), nameof(NoteCutSoundEffect.Init))]
+    private void Postfix(Saber saber, AudioSource ____audioSource, NoteCutSoundEffect __instance, bool ____noteWasCut, Saber ____saber)
+    {
+        if (config.PauseHitSoundWhenMissed)
+        {
+            // Mute the sound if the saber is not moving fast enough to ensure the woosh sound only plays when swinging. Or if the note is short.
+            if (!____noteWasCut)
+            {
+                bool flag = ____saber.bladeSpeed > 15f && !isNoteShort;
+                ____audioSource.mute = !flag;
+            }
+        }
+    }
+
+    [AffinityPatch(typeof(NoteCutSoundEffect), nameof(NoteCutSoundEffect.OnLateUpdate))]
+    private void Postfix(bool ____noteWasCut, AudioSource ____audioSource, double ____startDSPTime, float ____aheadTime, Saber ____saber)
+    {
+        if (____audioSource == null || !config.PauseHitSoundWhenMissed)
+            return;
+
+
+        // If the scheduled note time has passed and the note was not cut, pause the hitsound.
+        if (config.PauseHitSoundWhenMissed) 
+        {
+            // compute the note's DSP time (the time the note is considered "hit" by the audio scheduling)
+            double noteDSPTime = ____startDSPTime + (double)____aheadTime;
+            double pauseOffset = -0.02;
+            double pauseSpatializedOffset = -0.04; // 4 we give an earlier offset to mute the sound to prevent spatialization artifacts.
+            bool spatializerPresent = SpatializerDetectionHelper.spatializerPresent;
+            double offsetToUse = ____audioSource.spatialize & spatializerPresent ? pauseSpatializedOffset : pauseOffset;
+            if (!____noteWasCut && AudioSettings.dspTime >= noteDSPTime + offsetToUse)
+            {
+                ____audioSource.Pause();
+            }
+            else if (____noteWasCut)
+            {
+                ____audioSource.mute = false;
+                ____audioSource.UnPause();
+            }
+
+        }
+
+
+    }
+
+}
+

--- a/HitsoundTweaks/HarmonyPatches/NoteCutSoundEffect_Transform_Position_Patch.cs
+++ b/HitsoundTweaks/HarmonyPatches/NoteCutSoundEffect_Transform_Position_Patch.cs
@@ -1,9 +1,10 @@
-﻿using HarmonyLib;
-using HitsoundTweaks.Configuration;
-using SiraUtil.Affinity;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using HitsoundTweaks.Configuration;
+using SiraUtil.Affinity;
 using UnityEngine;
 
 namespace HitsoundTweaks.HarmonyPatches;
@@ -12,6 +13,23 @@ namespace HitsoundTweaks.HarmonyPatches;
  * These patches allow the user to configure whether or not the spatialized hitsound should follow the sabers
  * If disabled, the hitsound will always play at the player's feet
  */
+internal static class NoteCutSoundEffectExtensions
+{
+    // Store fade data for each NoteCutSoundEffect instance
+    // Using a table to separate data from the original class
+    private static readonly ConditionalWeakTable<NoteCutSoundEffect, FadeData> fadeTable = new();
+
+    public class FadeData
+    {
+        public Vector3 startPos;
+        public double startTime;
+        public float duration;
+        public bool active;
+    }
+
+    public static FadeData GetFadeData(this NoteCutSoundEffect instance)
+        => fadeTable.GetOrCreateValue(instance);
+}
 internal class NoteCutSoundEffect_Transform_Position_NoteWasCut_Patch : IAffinity
 {
     private readonly PluginConfig config;
@@ -46,27 +64,29 @@ internal class NoteCutSoundEffect_Transform_Position_NoteWasCut_Patch : IAffinit
     // set transform position if desired
     [AffinityPatch(typeof(NoteCutSoundEffect), nameof(NoteCutSoundEffect.NoteWasCut))]
     private void Postfix(NoteCutSoundEffect __instance, AudioSource ____audioSource, NoteController
-        ____noteController, bool ____goodCut, NoteController noteController, in NoteCutInfo noteCutInfo)
+        ____noteController, bool ____goodCut, NoteController noteController, in NoteCutInfo noteCutInfo, Saber ____saber)
     {
         if (____noteController != noteController)
         {
             return;
         }
-
-        if (!____goodCut)
-        {
-            ____audioSource.spatialize = true;
-            __instance.transform.position = noteCutInfo.cutPoint;
-            return;
-        }
-
         if (!config.StaticSoundPos && ____audioSource.spatialize)
         {
+
+            // Apply the transformed position
             __instance.transform.position = noteCutInfo.cutPoint;
+            if (config.followAfterCut)
+            {
+                var fade = __instance.GetFadeData();
+                fade.startPos = noteCutInfo.cutPoint;
+                fade.startTime = AudioSettings.dspTime;
+                fade.duration = (0.434f / ____audioSource.pitch); // the amount of time in seconds it takes for the sound to fully follow the saber.
+                fade.active = true;
+            }
+
         }
     }
 }
-
 internal class NoteCutSoundEffect_Transform_Position_LateUpdate_Patch : IAffinity
 {
     private readonly PluginConfig config;
@@ -100,14 +120,41 @@ internal class NoteCutSoundEffect_Transform_Position_LateUpdate_Patch : IAffinit
     }
 
     [AffinityPatch(typeof(NoteCutSoundEffect), nameof(NoteCutSoundEffect.OnLateUpdate))]
-    private void Postfix(bool ____noteWasCut, Saber ____saber, AudioSource ____audioSource, NoteCutSoundEffect
-        __instance)
+    private void Postfix(NoteCutSoundEffect __instance, AudioSource ____audioSource, Saber ____saber, bool ____noteWasCut)
     {
-        // set transform position if desired
         if (!____noteWasCut && !config.StaticSoundPos && ____audioSource.spatialize)
         {
-            __instance.transform.position = ____saber.saberBladeTopPos;
+            __instance.transform.position = ____saber.saberBladeTopPosForLogic;
         }
+        if (____audioSource.spatialize && !config.StaticSoundPos && config.followAfterCut)
+        {
+            // Get live saber midpoint positioning.
+            Vector3 liveMidSaberPos = (____saber.saberBladeTopPosForLogic + ____saber.saberBladeBottomPosForLogic) / 2;
+            // If fading, lerp from cutPoint to saber position over time
+            var fade = __instance.GetFadeData();
+            if (fade.active)
+            {
+                double elapsed = AudioSettings.dspTime - fade.startTime;
+                float t = Mathf.Clamp01((float)elapsed / fade.duration);
+                t = Mathf.SmoothStep(0f, 1f, t);
+
+                // Start near cutPoint, end up tracking the live saber position
+                Vector3 lerpedPos = Vector3.Lerp(fade.startPos, liveMidSaberPos, t);
+                __instance.transform.position = lerpedPos;
+
+                // Once fade fully completes, permanently follow saber
+                if (t >= 1f)
+                {
+                    fade.active = false;
+                }
+            }
+            else if (!fade.active)
+            {
+                // Continue following saber after fade completes
+                __instance.transform.position = liveMidSaberPos;
+            }
+        }
+
     }
 }
 
@@ -146,7 +193,7 @@ internal class NoteCutSoundEffect_Transform_Position_Init_Patch : IAffinity
         // not sure how necessary this is, but since the game does it I might as well too
         if (!config.StaticSoundPos && ____audioSource.spatialize)
         {
-            __instance.transform.position = saber.saberBladeTopPos;
+            __instance.transform.position = saber.saberBladeTopPosForLogic;
         }
     }
 }

--- a/HitsoundTweaks/HarmonyPatches/SpatializerDetectionHelper.cs
+++ b/HitsoundTweaks/HarmonyPatches/SpatializerDetectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using UnityEngine;
@@ -9,7 +9,7 @@ namespace HitsoundTweaks.HarmonyPatches
     public class SpatializerDetectionHelper : IInitializable
     {
         public static bool spatializerPresent;
-        // Try Unity API first, fallback to searching game folders for known spatializer DLLs
+        // See if a spatializer plugin is present through AudioSettings GetSpatializerPluginName method
         public void Initialize()
         {
             DetectSpatializerPlugin();
@@ -19,12 +19,12 @@ namespace HitsoundTweaks.HarmonyPatches
             string name = GetSpatializerPluginNameSafe();
             if (!string.IsNullOrEmpty(name))
             {
-                Plugin.Log.Info($"[HitsoundTweaks] Spatializer reported by Unity: {name}");
+                Plugin.Log.Info($"Spatializer reported by Unity: {name}");
                 spatializerPresent = true;
                 return name;
             }
             spatializerPresent = false;
-            Plugin.Log.Warn("[HitsoundTweaks] No spatializer plugin detected! Downgrade below or at 1.40.2 for a spatializer.");
+            Plugin.Log.Warn("No spatializer plugin detected! Downgrade below or at 1.40.2 for a spatializer.");
             return null;
         }
 

--- a/HitsoundTweaks/HarmonyPatches/SpatializerDetectionHelper.cs
+++ b/HitsoundTweaks/HarmonyPatches/SpatializerDetectionHelper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+using Zenject;
+
+namespace HitsoundTweaks.HarmonyPatches
+{
+    public class SpatializerDetectionHelper : IInitializable
+    {
+        public static bool spatializerPresent;
+        // Try Unity API first, fallback to searching game folders for known spatializer DLLs
+        public void Initialize()
+        {
+            DetectSpatializerPlugin();
+        }
+        public static string DetectSpatializerPlugin()
+        {
+            string name = GetSpatializerPluginNameSafe();
+            if (!string.IsNullOrEmpty(name))
+            {
+                Plugin.Log.Info($"[HitsoundTweaks] Spatializer reported by Unity: {name}");
+                spatializerPresent = true;
+                return name;
+            }
+            spatializerPresent = false;
+            Plugin.Log.Warn("[HitsoundTweaks] No spatializer plugin detected! Downgrade below or at 1.40.2 for a spatializer.");
+            return null;
+        }
+
+        private static string GetSpatializerPluginNameSafe()
+        {
+            try
+            {
+                var mi = typeof(AudioSettings).GetMethod("GetSpatializerPluginName", BindingFlags.Public | BindingFlags.Static);
+                if (mi != null)
+                {
+                    return mi.Invoke(null, null) as string;
+                }
+            }
+            catch
+            {
+                // API unavailable or reflection failed
+            }
+            return null;
+        }
+
+    }
+}

--- a/HitsoundTweaks/HitsoundTweaks.csproj
+++ b/HitsoundTweaks/HitsoundTweaks.csproj
@@ -137,6 +137,7 @@
   <ItemGroup>
     <EmbeddedResource Include="manifest.json" />
     <EmbeddedResource Include="UI\ModSettingsView.bsml" />
+    <EmbeddedResource Include="UI\ModSettingsView_NoSpatializer.bsml" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />

--- a/HitsoundTweaks/Installers/AppInstaller.cs
+++ b/HitsoundTweaks/Installers/AppInstaller.cs
@@ -18,7 +18,7 @@ public class AppInstaller : Installer
         Container.BindInstance(config).AsSingle();
 
         Container.BindInterfacesAndSelfTo<AudioSettingsVoicesManager>().AsSingle();
-
+        Container.BindInterfacesAndSelfTo<SpatializerDetectionHelper>().AsSingle();
         Container.BindInterfacesTo<AudioTimeSyncController_dspTimeOffset_Patch>().AsSingle();
         Container.BindInterfacesTo<Hitsound_Reliability_Patches>().AsSingle();
         Container.BindInterfacesTo<NoteCutSoundEffectManager_Proximity_Check_Patch>().AsSingle();

--- a/HitsoundTweaks/Installers/PlayerInstaller.cs
+++ b/HitsoundTweaks/Installers/PlayerInstaller.cs
@@ -15,5 +15,6 @@ public class PlayerInstaller : Installer
         Container.BindInterfacesTo<NoteCutSoundEffectManager_Chain_Element_Hitsound_Patch>().AsSingle();
         Container.BindInterfacesTo<NoteCutSoundEffectManager_Max_Active_SoundEffects_Patch>().AsSingle();
         Container.BindInterfacesTo<NoteCutSoundEffect_Chain_Element_Volume_Multiplier_Patch>().AsSingle();
+        Container.BindInterfacesTo<NoteCutSoundEffect_PauseOnMiss_Patch>().AsSingle();
     }
 }

--- a/HitsoundTweaks/UI/ModSettingsView.bsml
+++ b/HitsoundTweaks/UI/ModSettingsView.bsml
@@ -1,10 +1,12 @@
-﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
 	xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'
 	>
 	<settings-container>
 		<toggle-setting text='Ignore Saber Speed' hover-hint='When enabled, hitsounds always play even when the sabers are not moving.' value='ignore-saber-speed'></toggle-setting>
-		<toggle-setting text='Static Hitsound Position' hover-hint='When enabled, hitsounds are located at your feet, instead of your saber tips.' value='static-sound-pos'></toggle-setting>
+		<toggle-setting text='Pause Hitsound when missed' hover-hint='When enabled, any notes missed, hitsounds will be paused. May introduce spatialization artifacts.' value='PauseHitSoundWhenMissed'></toggle-setting>
 		<toggle-setting text='Hitsound Spatialization' hover-hint='When disabled, hitsounds will be played as-is without further processing, instead of being spatialized.' value='enable-spatialization'></toggle-setting>
+		<toggle-setting text='Static Hitsound Position' hover-hint='When enabled, hitsounds are located at your feet, instead of your saber tips.' value='static-sound-pos'></toggle-setting>
+		<toggle-setting text='Follow Saber After Slice' hover-hint='When enabled, hitsounds will follow the saber after the note was cut giving the saber a sort of resonance.' value='followAfterCut'></toggle-setting>
 		<slider-setting text='Random Pitch (min)' hover-hint='The minimum value for randomized hitsound pitch. If minimum and maximum are equal, hitsound pitch is not randomized.' show-buttons='true' min='0' max='2' increment='0.05' value='random-pitch-min'></slider-setting>
 		<slider-setting text='Random Pitch (max)' hover-hint='The maximum value for randomized hitsound pitch. If minimum and maximum are equal, hitsound pitch is not randomized.' show-buttons='true' min='0' max='2' increment='0.05' value='random-pitch-max'></slider-setting>
 		<toggle-setting text='Enable Chain Element Hitsounds' hover-hint='When enabled, hitsounds will be played for chain elements.' value='enable-chain-element-hitsounds'></toggle-setting>

--- a/HitsoundTweaks/UI/ModSettingsView_NoSpatializer.bsml
+++ b/HitsoundTweaks/UI/ModSettingsView_NoSpatializer.bsml
@@ -1,0 +1,15 @@
+﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+	xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'
+	>
+	<settings-container>
+		<toggle-setting text='Ignore Saber Speed' hover-hint='When enabled, hitsounds always play even when the sabers are not moving.' value='ignore-saber-speed'></toggle-setting>
+		<toggle-setting text='Pause Hitsound when missed' hover-hint='When enabled, any notes missed, hitsounds will be paused.' value='PauseHitSoundWhenMissed'></toggle-setting>
+		<toggle-setting text='Hitsound Spatialization' hover-hint='When disabled, hitsounds will be played as-is without further processing, instead of being spatialized. (Note: This version of beat saber doesnt have a spatializer so hitsounds will be stereo-panned rather than fully spatialized. True 3D spatialization is available in Beat Saber 1.40.2 or earlier.)' value='enable-spatialization'></toggle-setting>
+		<toggle-setting text='Static Hitsound Position' hover-hint='When enabled, hitsounds are located at your feet, instead of your saber tips.' value='static-sound-pos'></toggle-setting>
+		<toggle-setting text='Follow Saber After Slice' hover-hint='When enabled, hitsounds will follow the saber after the note was cut giving the saber a sort of resonance.' value='followAfterCut'></toggle-setting>
+		<slider-setting text='Random Pitch (min)' hover-hint='The minimum value for randomized hitsound pitch. If minimum and maximum are equal, hitsound pitch is not randomized.' show-buttons='true' min='0' max='2' increment='0.05' value='random-pitch-min'></slider-setting>
+		<slider-setting text='Random Pitch (max)' hover-hint='The maximum value for randomized hitsound pitch. If minimum and maximum are equal, hitsound pitch is not randomized.' show-buttons='true' min='0' max='2' increment='0.05' value='random-pitch-max'></slider-setting>
+		<toggle-setting text='Enable Chain Element Hitsounds' hover-hint='When enabled, hitsounds will be played for chain elements.' value='enable-chain-element-hitsounds'></toggle-setting>
+		<slider-setting text='Chain Volume Multiplier' hover-hint='Volume multiplier used for chain element hitsounds.' show-buttons='true' min='0' max='2' increment='0.05' value='chain-element-volume-multiplier'></slider-setting>
+	</settings-container>
+</bg>

--- a/HitsoundTweaks/UI/SettingsMenuManager.cs
+++ b/HitsoundTweaks/UI/SettingsMenuManager.cs
@@ -1,6 +1,7 @@
+using System;
 using BeatSaberMarkupLanguage.Settings;
 using HitsoundTweaks.Configuration;
-using System;
+using HitsoundTweaks.HarmonyPatches;
 using Zenject;
 
 namespace HitsoundTweaks.UI;
@@ -11,7 +12,8 @@ public class SettingsMenuManager : IInitializable, IDisposable
     private readonly PluginConfig config;
 
     private const string SettingsMenuName = "HitsoundTweaks";
-    private const string ResourcePath = "HitsoundTweaks.UI.ModSettingsView.bsml";
+    private const string ResourcePathNormal = "HitsoundTweaks.UI.ModSettingsView.bsml";
+    private const string ResourcePathNoSpatial = "HitsoundTweaks.UI.ModSettingsView_NoSpatializer.bsml";
 
     private SettingsMenuManager(BSMLSettings bsmlSettings, PluginConfig config)
     {
@@ -21,7 +23,21 @@ public class SettingsMenuManager : IInitializable, IDisposable
 
     public void Initialize()
     {
-        bsmlSettings.AddSettingsMenu(SettingsMenuName, ResourcePath, config);
+        // Detect spatializer once at startup and choose which BSML to register
+        string resource = ResourcePathNormal;
+        try
+        {
+            var detected = SpatializerDetectionHelper.DetectSpatializerPlugin();
+            if (string.IsNullOrEmpty(detected))
+                resource = ResourcePathNoSpatial;
+        }
+        catch
+        {
+            // On any detection error, fall back to the no-spatializer view
+            resource = ResourcePathNoSpatial;
+        }
+
+        bsmlSettings.AddSettingsMenu(SettingsMenuName, resource, config);
     }
 
     public void Dispose()

--- a/HitsoundTweaks/manifest.json
+++ b/HitsoundTweaks/manifest.json
@@ -3,7 +3,7 @@
   "id": "HitsoundTweaks",
   "name": "HitsoundTweaks",
   "author": "GalaxyMaster",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "description": "Adds more configurability to hitsounds, and fixes several base game bugs to make them more reliable and consistent.",
   "gameVersion": "1.40.3",
   "dependsOn": {

--- a/HitsoundTweaks/manifest.json
+++ b/HitsoundTweaks/manifest.json
@@ -8,7 +8,7 @@
   "gameVersion": "1.40.3",
   "dependsOn": {
     "BSIPA": "^4.3.5",
-    "BeatSaberMarkupLanguage": "^1.12.5",
+    "BeatSaberMarkupLanguage": "^1.12.4",
     "SiraUtil": "^3.1.14"
   }
 }


### PR DESCRIPTION
This is my first time contributing to any sort of open source project, so I apologize in advance if I make any mistakes.
All of these added features may not be necessary or useful, but I've added them because they are features I would like to see in hitsoundtweaks. With that said, feel free to add some of these features or close this PR if you don't find these features useful.

Features that I've added within the fork. 

1. Added a spatializer detector, so if the mod is installed on a Beat Saber version that doesn't contain an audio spatializer, it creates a message within the logs saying that their version of Beat Saber doesn't have a spatializer and to downgrade below 1.40.2 for spatialized hitsounds. I've also added it so that if a spatializer isn't present, the hover hint of the hitsound spatialization settings option explains that the hitsounds won't be spatialized and will be stereo-panned instead due to Unity's way of handling spatial audio without an audio spatializer.

2. Added an option where if the player doesn't cut a note, the hitsound will be paused at the point considered hit on hitsound scheduling, effectively making it so the player won't hear hitsounds unless they cut a note.

3. Also added an option to have it where the hitsound will follow the saber after its cut, giving a sort of resonance to the saber.

 

